### PR TITLE
adding okd-nvidia driver build; does not support vgu

### DIFF
--- a/container-builds/okd-nvidiadrivers/build/Dockerfile
+++ b/container-builds/okd-nvidiadrivers/build/Dockerfile
@@ -1,13 +1,9 @@
 # Stage 1
 FROM nvcr.io/nvidia/cuda:12.9.1-base-ubi9 AS build
-SHELL ["/bin/bash", "-c"]
-
 RUN dnf install -y git wget
 
 # Stage 2
 FROM quay.io/centos/centos:9
-
-LABEL org.opencontainers.image.source https://github.com/TampaDevs/cloud-development-gitops-infra
 ENV TARGETARCH=x86_64
 
 ARG BASE_URL=https://us.download.nvidia.com/XFree86/Linux-x86_64
@@ -23,11 +19,9 @@ ARG DRIVER_TOOLKIT_IMAGE
 ENV DRIVER_TOOLKIT_IMAGE=$DRIVER_TOOLKIT_IMAGE
 
 ENV NVIDIA_VISIBLE_DEVICES=void
-
 ENV PATH="$PATH:/user/local/bin"
 
-SHELL ["/bin/bash", "-c"]
-
+LABEL org.opencontainers.image.source https://gitlab.com/net-dev-net/lab/-/tree/main/container-builds/okd-nvidiadrivers
 RUN dnf makecache 
 RUN dnf install -y kmod util-linux 'dnf-command(download)' 
 RUN dnf install -y patch

--- a/container-builds/okd-nvidiadrivers/gpu-operator/Chart.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: gpu-operator
+description: Chart for the gpu-operator
+type: application
+icon: https://assets.nvidiagrid.net/ngc/logos/GPUoperator.png
+version: v1.0.0
+appVersion: v25.3.0

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/buildconfig-build-driver.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/buildconfig-build-driver.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+metadata:
+  name: build-driver
+  namespace: gpu-operator
+spec:
+  runPolicy: Serial
+  serviceAccount: builder
+  source:
+    contextDir: container-builds/okd-nvidiadrivers/build
+    git:
+      ref: main
+      uri: git@github.com:desyncit/lab.git
+    sourceSecret:
+      name: pull-from-github
+    type: Git
+  strategy:
+    dockerStrategy:
+      noCache: true
+    type: Docker
+  nodeSelector:
+    nvidia.com/gpu.present: "true"
+  output:
+    to:
+      kind: ImageStreamTag
+      name: driver:570.169-scos4.18
+  triggers:
+    - type: ConfigChange

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterpolicy-cluster-policy.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterpolicy-cluster-policy.yaml
@@ -1,0 +1,273 @@
+---
+apiVersion: nvidia.com/v1
+kind: ClusterPolicy
+metadata:
+  name: cluster-policy
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    app.kubernetes.io/version: "v25.3.0"
+    app.kubernetes.io/component: "gpu-operator"
+spec:
+  hostPaths:
+    rootFS: /
+    driverInstallDir: /run/nvidia/driver
+  operator:
+    runtimeClass: nvidia
+    initContainer:
+      repository: nvcr.io/nvidia
+      image: cuda
+      version: "12.8.1-base-ubi9"
+      imagePullPolicy: IfNotPresent
+  daemonsets:
+    labels:
+      app.kubernetes.io/managed-by: gpu-operator
+    tolerations:
+      - effect: NoSchedule
+        key: nvidia.com/gpu
+        operator: Exists
+    priorityClassName: system-node-critical
+    updateStrategy: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: "1"
+  validator:
+    repository: nvcr.io/nvidia/cloud-native
+    image: gpu-operator-validator
+    version: "v25.3.0"
+    imagePullPolicy: IfNotPresent
+    plugin:
+      env:
+        - name: WITH_WORKLOAD
+          value: "false"
+  mig:
+    strategy: single
+  psa:
+    enabled: false
+  cdi:
+    enabled: false
+    default: false
+  driver:
+    enabled: true
+    useNvidiaDriverCRD: false
+    kernelModuleType: auto
+    usePrecompiled: false
+    repository: image-registry.openshift-image-registry.svc:5000/gpu-operator
+    image: driver
+    version: "570.169"
+    imagePullPolicy: Always
+    startupProbe:
+      failureThreshold: 120
+      initialDelaySeconds: 60
+      periodSeconds: 10
+      timeoutSeconds: 60
+    rdma:
+      enabled: false
+      useHostMofed: false
+    manager:
+      repository: nvcr.io/nvidia/cloud-native
+      image: k8s-driver-manager
+      version: "v0.8.0"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: ENABLE_GPU_POD_EVICTION
+          value: "true"
+        - name: ENABLE_AUTO_DRAIN
+          value: "false"
+        - name: DRAIN_USE_FORCE
+          value: "false"
+        - name: DRAIN_POD_SELECTOR_LABEL
+          value: ""
+        - name: DRAIN_TIMEOUT_SECONDS
+          value: 0s
+        - name: DRAIN_DELETE_EMPTYDIR_DATA
+          value: "false"
+    repoConfig:
+      configMapName: ""
+    certConfig:
+      name: ""
+    licensingConfig:
+      configMapName: ""
+      nlsEnabled: false
+    virtualTopology:
+      config: ""
+    kernelModuleConfig:
+      name: ""
+    upgradePolicy:
+      autoUpgrade: false
+      maxParallelUpgrades: 0
+      maxUnavailable : 25%
+      waitForCompletion:
+        timeoutSeconds: 0
+      podDeletion:
+        force: true
+        timeoutSeconds: 300
+        deleteEmptyDir: true
+      drain:
+        enable: false
+        force: false
+        timeoutSeconds: 300
+        deleteEmptyDir: false
+  vgpuManager:
+    enabled: false
+    image: vgpu-manager
+    version: "v25.3.1"
+    imagePullPolicy: IfNotPresent
+    driverManager:
+      repository: nvcr.io/nvidia/cloud-native
+      image: k8s-driver-manager
+      version: "v0.8.0"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: ENABLE_GPU_POD_EVICTION
+          value: "false"
+        - name: ENABLE_AUTO_DRAIN
+          value: "false"
+  kataManager:
+    enabled: false
+    config:
+      artifactsDir: /opt/gpu-operator/artifacts/runtimeclasses
+      runtimeClasses:
+      - artifacts:
+          pullSecret: ""
+          url: nvcr.io/nvidia/cloud-native/kata-gpu-artifacts:ubuntu22.04-535.54.03
+        name: kata-nvidia-gpu
+        nodeSelector: {}
+      - artifacts:
+          pullSecret: ""
+          url: nvcr.io/nvidia/cloud-native/kata-gpu-artifacts:ubuntu22.04-535.86.10-snp
+        name: kata-nvidia-gpu-snp
+        nodeSelector:
+          nvidia.com/cc.capable: "true"
+    repository: nvcr.io/nvidia/cloud-native
+    image: k8s-kata-manager
+    version: "v0.2.3"
+    imagePullPolicy: IfNotPresent
+  vfioManager:
+    enabled: true
+    repository: nvcr.io/nvidia
+    image: cuda
+    version: "12.8.1-base-ubi9"
+    imagePullPolicy: IfNotPresent
+    driverManager:
+      repository: nvcr.io/nvidia/cloud-native
+      image: k8s-driver-manager
+      version: "v0.8.0"
+      imagePullPolicy: IfNotPresent
+      env:
+        - name: ENABLE_GPU_POD_EVICTION
+          value: "false"
+        - name: ENABLE_AUTO_DRAIN
+          value: "false"
+  vgpuDeviceManager:
+    enabled: false
+    repository: nvcr.io/nvidia/cloud-native
+    image: vgpu-device-manager
+    version: "v0.3.0"
+    imagePullPolicy: IfNotPresent
+    config:
+      default: default
+      name: ""
+  ccManager:
+    enabled: false
+    defaultMode: "off"
+    repository: nvcr.io/nvidia/cloud-native
+    image: k8s-cc-manager
+    version: "v0.1.1"
+    imagePullPolicy: IfNotPresent
+    env:
+      []
+  toolkit:
+    enabled: true
+    repository: nvcr.io/nvidia/k8s
+    image: container-toolkit
+    version: "v1.17.8-ubuntu20.04"
+    imagePullPolicy: IfNotPresent
+    installDir: /usr/local/nvidia
+  devicePlugin:
+    enabled: true
+    repository: nvcr.io/nvidia
+    image: k8s-device-plugin
+    version: "v0.17.2"
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: PASS_DEVICE_SPECS
+        value: "true"
+      - name: FAIL_ON_INIT_ERROR
+        value: "true"
+      - name: DEVICE_LIST_STRATEGY
+        value: envvar
+      - name: DEVICE_ID_STRATEGY
+        value: uuid
+      - name: NVIDIA_VISIBLE_DEVICES
+        value: all
+      - name: NVIDIA_DRIVER_CAPABILITIES
+        value: all
+  dcgm:
+    enabled: true
+    repository: nvcr.io/nvidia/cloud-native
+    image: dcgm
+    version: "4.2.3-1-ubuntu22.04"
+    imagePullPolicy: IfNotPresent
+  dcgmExporter:
+    enabled: true
+    repository: nvcr.io/nvidia/k8s
+    image: dcgm-exporter
+    version: "4.2.3-4.1.3-ubuntu22.04"
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: DCGM_EXPORTER_LISTEN
+        value: :9400
+      - name: DCGM_EXPORTER_KUBERNETES
+        value: "true"
+      - name: DCGM_EXPORTER_COLLECTORS
+        value: /etc/dcgm-exporter/dcp-metrics-included.csv
+    serviceMonitor:
+      additionalLabels: {}
+      enabled: false
+      honorLabels: false
+      interval: 15s
+      relabelings: []
+  gfd:
+    enabled: false
+    repository: nvcr.io/nvidia
+    image: k8s-device-plugin
+    version: "v0.17.2"
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: GFD_SLEEP_INTERVAL
+        value: 60s
+      - name: GFD_FAIL_ON_INIT_ERROR
+        value: "true"
+  migManager:
+    enabled: false
+    repository: nvcr.io/nvidia/cloud-native
+    image: k8s-mig-manager
+    version: "v0.12.1-ubuntu20.04"
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: WITH_REBOOT
+        value: "false"
+    config:
+      name:
+      default: all-disabled
+    gpuClientsConfig:
+      name: ""
+  nodeStatusExporter:
+    enabled: true
+    repository: nvcr.io/nvidia/cloud-native
+    image: gpu-operator-validator
+    version: "v25.3.1"
+    imagePullPolicy: IfNotPresent
+  gdrcopy:
+    enabled: false
+    repository: nvcr.io/nvidia/cloud-native
+    image: gdrdrv
+    version: "v2.5"
+    imagePullPolicy: IfNotPresent
+  sandboxWorkloads:
+    enabled: false
+    defaultWorkload: container
+  sandboxDevicePlugin:
+    repository: nvcr.io/nvidia
+    image: kubevirt-gpu-device-plugin
+    version: "v1.3.1"
+    imagePullPolicy: IfNotPresent

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterrole-gpu-operator-upgrade.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterrole-gpu-operator-upgrade.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gpu-operator-upgrade-crd-hook-role
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - create
+      - get
+      - list
+      - watch
+      - patch
+      - update

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterrole-gpu-operator.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterrole-gpu-operator.yaml
@@ -1,0 +1,154 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gpu-operator
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    app.kubernetes.io/version: "v25.3.0"
+    app.kubernetes.io/component: "gpu-operator"
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - image.openshift.io
+  resources:
+  - imagestreams
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - use
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/eviction
+  verbs:
+  - create
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - nvidia.com
+  resources:
+  - clusterpolicies
+  - clusterpolicies/finalizers
+  - clusterpolicies/status
+  - nvidiadrivers
+  - nvidiadrivers/finalizers
+  - nvidiadrivers/status
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+  - deletecollection
+- apiGroups:
+  - scheduling.k8s.io
+  resources:
+  - priorityclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+- apiGroups:
+  - node.k8s.io
+  resources:
+  - runtimeclasses
+  verbs:
+  - get
+  - list
+  - create
+  - update
+  - watch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - create

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterrolebinding-gpu-operator-upgrade.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterrolebinding-gpu-operator-upgrade.yaml
@@ -1,0 +1,17 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gpu-operator-upgrade-crd-hook-binding
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    helm.sh/hook-weight: "0"
+subjects:
+  - kind: ServiceAccount
+    name: gpu-operator-upgrade-crd-hook-sa
+    namespace: gpu-operator
+roleRef:
+  kind: ClusterRole
+  name: gpu-operator-upgrade-crd-hook-role
+  apiGroup: rbac.authorization.k8s.io

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterrolebinding-gpu-operator.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/clusterrolebinding-gpu-operator.yaml
@@ -1,0 +1,103 @@
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gpu-operator
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    app.kubernetes.io/version: "v25.3.0"
+    app.kubernetes.io/component: "gpu-operator"
+subjects:
+- kind: ServiceAccount
+  name: gpu-operator
+  namespace: gpu-operator
+roleRef:
+  kind: ClusterRole
+  name: gpu-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: gpu-operator
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    app.kubernetes.io/version: "v25.3.0"
+    app.kubernetes.io/component: "gpu-operator"
+rules:
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - controllerrevisions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - pods
+  - pods/eviction
+  - secrets
+  - services
+  - services/finalizers
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  - prometheusrules
+  verbs:
+  - get
+  - list
+  - create
+  - watch
+  - update
+  - delete

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/deployment-gpu-operator.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/deployment-gpu-operator.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gpu-operator
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    app.kubernetes.io/version: "v25.3.0"
+    app.kubernetes.io/component: "gpu-operator"
+    nvidia.com/gpu-driver-upgrade-drain.skip: "true"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: "gpu-operator"
+      app: "gpu-operator"
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gpu-operator
+        helm.sh/chart: gpu-operator-v25.3.0
+        app.kubernetes.io/version: "v25.3.0"
+        app.kubernetes.io/component: "gpu-operator"
+        app: "gpu-operator"
+        nvidia.com/gpu-driver-upgrade-drain.skip: "true"
+      annotations:
+        openshift.io/scc: sysadmin
+    spec:
+      serviceAccountName: gpu-operator
+      priorityClassName: system-node-critical
+      containers:
+      - name: gpu-operator
+        image: nvcr.io/nvidia/gpu-operator:v25.3.1
+        imagePullPolicy: IfNotPresent
+        command: ["gpu-operator"]
+        args:
+        - --leader-elect
+        - --zap-time-encoding=epoch
+        - --zap-log-level=info
+        env:
+        - name: WATCH_NAMESPACE
+          value: ""
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: "DRIVER_MANAGER_IMAGE"
+          value: "nvcr.io/nvidia/cloud-native/k8s-driver-manager:v0.8.0"
+        volumeMounts:
+          - name: host-os-release
+            mountPath: "/host-etc/os-release"
+            readOnly: true
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          limits:
+            cpu: 500m
+            memory: 350Mi
+          requests:
+            cpu: 200m
+            memory: 100Mi
+        ports:
+          - name: metrics
+            containerPort: 8080
+      volumes:
+        - name: host-os-release
+          hostPath:
+            path: "/etc/os-release"
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - preference:
+              matchExpressions:
+              - key: node-role.kubernetes.io/control-plane
+                operator: In
+                values:
+                - ""
+            weight: 1
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Equal
+          value: ""

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/imagestream-driver.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/imagestream-driver.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  name: driver
+  namespace: gpu-operator
+  labels:
+    app.kubernetes.io/instance: gpu-operator
+spec:
+  dockerImageRepository: 'image-registry.openshift-image-registry.svc:5000/gpu-operator/driver'
+  lookupPolicy:
+    local: true
+  tags:
+    - name: 570.169-scos4.18
+      annotations: null
+      generation: 1
+      importPolicy:
+        importMode: Legacy
+      referencePolicy:
+        type: Local

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/job-gpu-operator-upgrade.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/job-gpu-operator-upgrade.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: gpu-operator-upgrade-crd
+  namespace: gpu-operator
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    helm.sh/chart: gpu-operator-v25.3.0
+    app.kubernetes.io/instance: gpu-operator-1753039074
+    app.kubernetes.io/version: "v25.3.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "gpu-operator"
+spec:
+  template:
+    metadata:
+      name: gpu-operator-upgrade-crd
+      labels:
+        app.kubernetes.io/name: gpu-operator
+        helm.sh/chart: gpu-operator-v25.3.0
+        app.kubernetes.io/instance: gpu-operator-1753039074
+        app.kubernetes.io/version: "v25.3.0"
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/component: "gpu-operator"
+    spec:
+      serviceAccountName: gpu-operator-upgrade-crd-hook-sa
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+          operator: Equal
+          value: ""
+      containers:
+        - name: upgrade-crd
+          image: nvcr.io/nvidia/gpu-operator:v25.3.1
+          imagePullPolicy: IfNotPresent
+          command:
+          - /bin/sh
+          - -c
+          - >
+            kubectl apply -f /opt/gpu-operator/nvidia.com_clusterpolicies.yaml;
+            kubectl apply -f /opt/gpu-operator/nvidia.com_nvidiadrivers.yaml;
+      restartPolicy: OnFailure
+

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/rolebinding-gpu-operator.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/rolebinding-gpu-operator.yaml
@@ -1,0 +1,20 @@
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gpu-operator
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    helm.sh/chart: gpu-operator-v25.3.0
+    app.kubernetes.io/instance: gpu-operator-1753039074
+    app.kubernetes.io/version: "v25.3.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "gpu-operator"
+subjects:
+- kind: ServiceAccount
+  name: gpu-operator
+  namespace: gpu-operator
+roleRef:
+  kind: Role
+  name: gpu-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-dcgm-exporter.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-dcgm-exporter.yaml
@@ -1,0 +1,44 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+- system:nodes
+- system:masters
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
+      only for cluster administration. Grant with caution.'
+  labels:
+    app.kubernetes.io/instance: gpu-operator
+  name: nvidia-dcgm-exporter
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:gpu-operator:nvidia-dcgm-exporter
+volumes:
+- '*'

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-dcgm.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-dcgm.yaml
@@ -1,0 +1,44 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: true
+allowHostPID: false
+allowHostPorts: true
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+- system:nodes
+- system:masters
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
+      only for cluster administration. Grant with caution.'
+  labels:
+    app.kubernetes.io/instance: gpu-operator
+  name: nvidia-dcgm
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:gpu-operator:nvidia-dcgm
+volumes:
+- '*'

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-driver.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-driver.yaml
@@ -1,0 +1,44 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+- system:nodes
+- system:masters
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
+      only for cluster administration. Grant with caution.'
+  labels:
+    app.kubernetes.io/instance: gpu-operator
+  name: nvidia-driver
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:gpu-operator:nvidia-driver
+volumes:
+- '*'

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-node-status-exporter.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-node-status-exporter.yaml
@@ -1,0 +1,44 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+- system:nodes
+- system:masters
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
+      only for cluster administration. Grant with caution.'
+  labels:
+    app.kubernetes.io/instance: gpu-operator
+  name: nvidia-node-status-exporter
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:gpu-operator:nvidia-node-status-exporter
+volumes:
+- '*'

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-operator-validator.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/scc-nvidia-operator-validator.yaml
@@ -1,0 +1,44 @@
+allowHostDirVolumePlugin: true
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: true
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: true
+allowedCapabilities:
+- '*'
+allowedUnsafeSysctls:
+- '*'
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups:
+- system:cluster-admins
+- system:nodes
+- system:masters
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    kubernetes.io/description: 'privileged allows access to all privileged and host
+      features and the ability to run as any user, any group, any fsGroup, and with
+      any SELinux context.  WARNING: this is the most relaxed SCC and should be used
+      only for cluster administration. Grant with caution.'
+  labels:
+    app.kubernetes.io/instance: gpu-operator
+  name: nvidia-operator-validator
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities: null
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+- '*'
+supplementalGroups:
+  type: RunAsAny
+users:
+- system:serviceaccount:gpu-operator:nvidia-operator-validator
+volumes:
+- '*'

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/service-account-gpu-operator.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/service-account-gpu-operator.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gpu-operator-upgrade-crd-hook-sa
+  annotations:
+    helm.sh/hook: pre-upgrade
+    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+    helm.sh/hook-weight: "0"

--- a/container-builds/okd-nvidiadrivers/gpu-operator/templates/serviceaccount-gpu-operator.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/templates/serviceaccount-gpu-operator.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gpu-operator
+  labels:
+    app.kubernetes.io/name: gpu-operator
+    helm.sh/chart: gpu-operator-v25.3.0
+    app.kubernetes.io/instance: gpu-operator-1753039074
+    app.kubernetes.io/version: "v25.3.0"
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: "gpu-operator"

--- a/container-builds/okd-nvidiadrivers/gpu-operator/values.yaml
+++ b/container-builds/okd-nvidiadrivers/gpu-operator/values.yaml
@@ -1,0 +1,517 @@
+---
+platform:
+  openshift: true
+
+nfd:
+  enabled: false
+  nodefeaturerules: false
+
+psa:
+  enabled: false
+
+cdi:
+  enabled: false
+  default: false
+
+sandboxWorkloads:
+  enabled: false
+  defaultWorkload: "container"
+
+hostPaths:
+  rootFS: "/"
+  driverInstallDir: "/run/nvidia/driver"
+
+daemonsets:
+  labels: {}
+  annotations: {}
+  priorityClassName: system-node-critical
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  updateStrategy: "RollingUpdate"
+  rollingUpdate:
+    maxUnavailable: "1"
+
+validator:
+  repository: nvcr.io/nvidia/cloud-native
+  image: gpu-operator-validator
+  version: ""
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env: []
+  args: []
+  resources: {}
+  plugin:
+    env:
+      - name: WITH_WORKLOAD
+        value: "false"
+
+operator:
+  repository: nvcr.io/nvidia
+  image: gpu-operator
+  version: "v25.3.1"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  priorityClassName: system-node-critical
+  runtimeClass: nvidia
+  use_ocp_driver_toolkit: false
+  cleanupCRD: false
+  upgradeCRD: true
+  initContainer:
+    image: cuda
+    repository: nvcr.io/nvidia
+    version: 12.8.1-base-ubi9
+    imagePullPolicy: IfNotPresent
+  tolerations:
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Equal"
+    value: ""
+    effect: "NoSchedule"
+  annotations:
+    openshift.io/scc: sysadmin
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 1
+          preference:
+            matchExpressions:
+              - key: "node-role.kubernetes.io/control-plane"
+                operator: In
+                values: [""]
+  logging:
+    timeEncoding: epoch
+    level: info
+    develMode: false
+  resources:
+    limits:
+      cpu: 500m
+      memory: 350Mi
+    requests:
+      cpu: 200m
+      memory: 100Mi
+
+mig:
+  strategy: single
+
+driver:
+  enabled: true
+  nvidiaDriverCRD:
+    enabled: false
+    deployDefaultCR: true
+    driverType: gpu
+    nodeSelector:
+      nvidia.com/gpu.present: ""
+  kernelModuleType: "auto"
+  usePrecompiled: false
+  repository: image-registry.openshift-image-registry.svc:5000/gpu-operator
+  image: driver
+  version: "570.169"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  startupProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    timeoutSeconds: 60
+    failureThreshold: 120
+  rdma:
+    enabled: false
+    useHostMofed: false
+  upgradePolicy:
+    autoUpgrade: false
+    maxParallelUpgrades: 0
+    maxUnavailable: 25%
+    waitForCompletion:
+      timeoutSeconds: 0
+      podSelector: ""
+    gpuPodDeletion:
+      force: true
+      timeoutSeconds: 300
+      deleteEmptyDir: true
+    drain:
+      enable: false
+      force: false
+      podSelector: ""
+      timeoutSeconds: 300
+      deleteEmptyDir: false
+  manager:
+    image: k8s-driver-manager
+    repository: nvcr.io/nvidia/cloud-native
+    version: v0.8.0
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: ENABLE_GPU_POD_EVICTION
+        value: "true"
+      - name: ENABLE_AUTO_DRAIN
+        value: "false"
+      - name: DRAIN_USE_FORCE
+        value: "false"
+      - name: DRAIN_POD_SELECTOR_LABEL
+        value: ""
+      - name: DRAIN_TIMEOUT_SECONDS
+        value: "0s"
+      - name: DRAIN_DELETE_EMPTYDIR_DATA
+        value: "false"
+  env: []
+  resources: {}
+  repoConfig:
+    configMapName: ""
+  certConfig:
+    name: ""
+  licensingConfig:
+    configMapName: ""
+    nlsEnabled: false
+  virtualTopology:
+    config: ""
+  kernelModuleConfig:
+    name: ""
+
+toolkit:
+  enabled: true
+  repository: nvcr.io/nvidia/k8s
+  image: container-toolkit
+  version: v1.17.8-ubuntu20.04
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env: []
+  resources: {}
+  installDir: "/usr/local/nvidia"
+
+devicePlugin:
+  enabled: true
+  repository: nvcr.io/nvidia
+  image: k8s-device-plugin
+  version: v0.17.2
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  args: []
+  env:
+    - name: PASS_DEVICE_SPECS
+      value: "true"
+    - name: FAIL_ON_INIT_ERROR
+      value: "true"
+    - name: DEVICE_LIST_STRATEGY
+      value: envvar
+    - name: DEVICE_ID_STRATEGY
+      value: uuid
+    - name: NVIDIA_VISIBLE_DEVICES
+      value: all
+    - name: NVIDIA_DRIVER_CAPABILITIES
+      value: all
+  resources: {}
+  # Plugin configuration
+  # Use "name" to either point to an existing ConfigMap or to create a new one with a list of configurations(i.e with create=true).
+  # Use "data" to build an integrated ConfigMap from a set of configurations as
+  # part of this helm chart. An example of setting "data" might be:
+  # config:
+  #   name: device-plugin-config
+  #   create: true
+  #   data:
+  #     default: |-
+  #       version: v1
+  #       flags:
+  #         migStrategy: none
+  #     mig-single: |-
+  #       version: v1
+  #       flags:
+  #         migStrategy: single
+  #     mig-mixed: |-
+  #       version: v1
+  #       flags:
+  #         migStrategy: mixed
+  config:
+    create: false
+    name: ""
+    default: ""
+    data: {}  
+  mps:
+    root: "/run/nvidia/mps"
+
+dcgm:
+  enabled: true
+  repository: nvcr.io/nvidia/cloud-native
+  image: dcgm
+  version: 4.2.3-1-ubuntu22.04
+  imagePullPolicy: IfNotPresent
+  args: []
+  env: []
+  resources: {}
+
+dcgmExporter:
+  enabled: true
+  repository: nvcr.io/nvidia/k8s
+  image: dcgm-exporter
+  version: 4.2.3-4.1.3-ubuntu22.04
+  imagePullPolicy: IfNotPresent
+  env:
+    - name: DCGM_EXPORTER_LISTEN
+      value: ":9400"
+    - name: DCGM_EXPORTER_KUBERNETES
+      value: "true"
+    - name: DCGM_EXPORTER_COLLECTORS
+      value: "/etc/dcgm-exporter/dcp-metrics-included.csv"
+  resources: {}
+  service:
+    internalTrafficPolicy: Cluster
+  serviceMonitor:
+    enabled: false
+    interval: 15s
+    honorLabels: false
+    additionalLabels: {}
+    relabelings: []
+    # - source_labels:
+    #     - __meta_kubernetes_pod_node_name
+    #   regex: (.*)
+    #   target_label: instance
+    #   replacement: $1
+    #   action: replace
+  # DCGM Exporter configuration
+  # This block is used to configure DCGM Exporter to emit a customized list of metrics.
+  # Use "name" to either point to an existing ConfigMap or to create a new one with a
+  # list of configurations (i.e with create=true).
+  # When pointing to an existing ConfigMap, the ConfigMap must exist in the same namespace as the release.
+  # The metrics are expected to be listed under a key called `dcgm-metrics.csv`.
+  # Use "data" to build an integrated ConfigMap from a set of custom metrics as
+  # part of the chart. An example of some custom metrics are shown below. Note that
+  # the contents of "data" must be in CSV format and be valid DCGM Exporter metric configurations.
+  # config:
+    # name: custom-dcgm-exporter-metrics
+    # create: true
+    # data: |-
+      # Format
+      # If line starts with a '#' it is considered a comment
+      # DCGM FIELD, Prometheus metric type, help message
+
+      # Clocks
+      # DCGM_FI_DEV_SM_CLOCK,  gauge, SM clock frequency (in MHz).
+      # DCGM_FI_DEV_MEM_CLOCK, gauge, Memory clock frequency (in MHz).
+gfd:
+  enabled: false
+  repository: nvcr.io/nvidia
+  image: k8s-device-plugin
+  version: v0.17.2
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env:
+    - name: GFD_SLEEP_INTERVAL
+      value: 60s
+    - name: GFD_FAIL_ON_INIT_ERROR
+      value: "true"
+  resources: {}
+
+migManager:
+  enabled: false
+  repository: nvcr.io/nvidia/cloud-native
+  image: k8s-mig-manager
+  version: v0.12.1-ubuntu20.04
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env:
+    - name: WITH_REBOOT
+      value: "false"
+  resources: {}
+  # MIG configuration
+  # Use "name" to either point to an existing ConfigMap or to create a new one with a list of configurations(i.e with create=true).
+  # Use "data" to build an integrated ConfigMap from a set of configurations as
+  # part of this helm chart. An example of setting "data" might be:
+  # config:
+  #   name: custom-mig-parted-configs
+  #   create: true
+  #   data:
+  #     config.yaml: |-
+  #       version: v1
+  #       mig-configs:
+  #         all-disabled:
+  #           - devices: all
+  #             mig-enabled: false
+  #         custom-mig:
+  #           - devices: [0]
+  #             mig-enabled: false
+  #           - devices: [1]
+  #              mig-enabled: true
+  #              mig-devices:
+  #                "1g.10gb": 7
+  #           - devices: [2]
+  #             mig-enabled: true
+  #             mig-devices:
+  #               "2g.20gb": 2
+  #               "3g.40gb": 1
+  #           - devices: [3]
+  #             mig-enabled: true
+  #             mig-devices:
+  #               "3g.40gb": 1
+  #               "4g.40gb": 1
+  config:
+    default: "all-disabled"
+    create: false
+    name: ""
+    data: {}
+  gpuClientsConfig:
+    name: ""
+
+nodeStatusExporter:
+  enabled: true
+  repository: nvcr.io/nvidia/cloud-native
+  image: gpu-operator-validator
+  version: "v25.3.1"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  resources: {}
+
+gds:
+  enabled: false
+  repository: nvcr.io/nvidia/cloud-native
+  image: nvidia-fs
+  version: "2.20.5"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env: []
+  args: []
+
+gdrcopy:
+  enabled: false
+  repository: nvcr.io/nvidia/cloud-native
+  image: gdrdrv
+  version: "v2.5"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env: []
+  args: []
+
+vgpuManager:
+  enabled: false
+  repository: ""
+  image: vgpu-manager
+  version: "v25.3.1"
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env: []
+  resources: {}
+  driverManager:
+    image: k8s-driver-manager
+    repository: nvcr.io/nvidia/cloud-native
+    version: v0.8.0
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: ENABLE_GPU_POD_EVICTION
+        value: "false"
+      - name: ENABLE_AUTO_DRAIN
+        value: "false"
+
+vgpuDeviceManager:
+  enabled: false
+  repository: nvcr.io/nvidia/cloud-native
+  image: vgpu-device-manager
+  version: v0.3.0
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env: []
+  config:
+    name: ""
+    default: "default"
+
+vfioManager:
+  enabled: true
+  repository: nvcr.io/nvidia
+  image: cuda
+  version: 12.8.1-base-ubi9
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env: []
+  resources: {}
+  driverManager:
+    image: k8s-driver-manager
+    repository: nvcr.io/nvidia/cloud-native
+    version: v0.8.0
+    imagePullPolicy: IfNotPresent
+    env:
+      - name: ENABLE_GPU_POD_EVICTION
+        value: "false"
+      - name: ENABLE_AUTO_DRAIN
+        value: "false"
+
+kataManager:
+  enabled: false
+  config:
+    artifactsDir: "/opt/nvidia-gpu-operator/artifacts/runtimeclasses"
+    runtimeClasses:
+      - name: kata-nvidia-gpu
+        nodeSelector: {}
+        artifacts:
+          url: nvcr.io/nvidia/cloud-native/kata-gpu-artifacts:ubuntu22.04-535.54.03
+          pullSecret: ""
+      - name: kata-nvidia-gpu-snp
+        nodeSelector:
+          "nvidia.com/cc.capable": "true"
+        artifacts:
+          url: nvcr.io/nvidia/cloud-native/kata-gpu-artifacts:ubuntu22.04-535.86.10-snp
+          pullSecret: ""
+  repository: nvcr.io/nvidia/cloud-native
+  image: k8s-kata-manager
+  version: v0.2.3
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env: []
+  resources: {}
+
+sandboxDevicePlugin:
+  enabled: false
+  repository: nvcr.io/nvidia
+  image: kubevirt-gpu-device-plugin
+  version: v1.3.1
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  args: []
+  env: []
+  resources: {}
+
+ccManager:
+  enabled: false
+  defaultMode: "off"
+  repository: nvcr.io/nvidia/cloud-native
+  image: k8s-cc-manager
+  version: v0.1.1
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+  env:
+    - name: CC_CAPABLE_DEVICE_IDS
+      value: "0x2339,0x2331,0x2330,0x2324,0x2322,0x233d"
+  resources: {}
+
+node-feature-discovery:
+  priorityClassName: system-node-critical
+  gc:
+    enable: false
+    replicaCount: 1
+    serviceAccount:
+      name: node-feature-discovery
+      create: false
+  worker:
+    serviceAccount:
+      name: node-feature-discovery
+      create: false
+    tolerations:
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Equal"
+      value: ""
+      effect: "NoSchedule"
+    - key: nvidia.com/gpu
+      operator: Exists
+      effect: NoSchedule
+    config:
+      sources:
+        pci:
+          deviceClassWhitelist:
+          - "02"
+          - "0200"
+          - "0207"
+          - "0300"
+          - "0302"
+          deviceLabelFields:
+          - vendor
+  master:
+    serviceAccount:
+      name: node-feature-discovery
+      create: false
+    config:
+      extraLabelNs: ["nvidia.com"]


### PR DESCRIPTION
modified nvidia driver deployment for use in the Tampa Devs cloud environment.

Removed alot the nvidia fabric and vgpu stuff as I don't have a license for it and don't need it


Based on 
- [nvidia/container-images/driver/main/coreos](https://gitlab.com/nvidia/container-images/driver/-/tree/main/coreos) 
- [nvidia/gpu-driver-container](https://github.com/NVIDIA/gpu-driver-container/tree/main)
